### PR TITLE
re-use the modifiedPaths list

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -1103,12 +1103,12 @@ Document.prototype.modifiedPaths = function() {
  * @api public
  */
 
-Document.prototype.isModified = function(paths) {
+Document.prototype.isModified = function(paths, modifiedPaths) {
   if (paths) {
     if (!Array.isArray(paths)) {
       paths = paths.split(' ');
     }
-    var modified = this.modifiedPaths();
+    var modified = modifiedPaths || this.modifiedPaths();
     var directModifiedPaths = Object.keys(this.$__.activePaths.states.modify);
     var isModifiedChild = paths.some(function(path) {
       return !!~modified.indexOf(path);
@@ -1394,9 +1394,10 @@ function _getPathsToValidate(doc) {
     var subdocs = doc.$__getAllSubdocs();
     var subdoc;
     len = subdocs.length;
+    var modifiedPaths = doc.modifiedPaths();
     for (i = 0; i < len; ++i) {
       subdoc = subdocs[i];
-      if (doc.isModified(subdoc.$basePath) &&
+      if (doc.isModified(subdoc.$basePath, isModified) &&
           !doc.isDirectModified(subdoc.$basePath)) {
         // Remove child paths for now, because we'll be validating the whole
         // subdoc


### PR DESCRIPTION
In _getPathsToValidate the `doc.modifedPaths()` function is called for every subDoc. the result of the function is same, thereby wasting time and computation to calculate it for every subDoc. This becomes a time hog in documents with a lot of `EmbeddedDocuments`